### PR TITLE
Add sandbox build/test npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,12 +211,29 @@ npm run test:deno
 # Build for Node.js (primary)
 npm run build
 
+# Build the C++ bindings with the real headers
+npm run build:real
+
+# Build the C++ bindings with sandbox headers
+npm run build:sandbox
+
+# Test C++ modules with the real headers
+npm run test:real
+
+# Test C++ modules with sandbox headers
+npm run test:sandbox
+
 # Build TypeScript only
 npm run build:ts
 
 # Development mode (watch)
 npm run dev
 ```
+
+The `SANDBOX_BUILD` environment variable controls whether real N-API headers
+or lightweight sandbox stubs are used. `build:real` and `test:real` run with
+`SANDBOX_BUILD=0`, while the `build:sandbox` and `test:sandbox` scripts set
+`SANDBOX_BUILD=1`.
 
 ## 🧪 Test-Driven Development (TDD)
 

--- a/package.json
+++ b/package.json
@@ -32,9 +32,13 @@
     "format": "prettier --config .prettierrc --write src/**/*.ts",
     "docs": "typedoc src --out docs",
     "prepublishOnly": "npm run build && npm test",
+    "build:real": "SANDBOX_BUILD=0 npm run build:cpp",
+    "build:sandbox": "SANDBOX_BUILD=1 npm run build:cpp",
     "build:cpp": "bash src/bindings/build.sh build",
     "build:cpp:module": "bash src/bindings/build.sh build",
     "build:cpp:binding": "bash src/bindings/build.sh binding",
+    "test:real": "SANDBOX_BUILD=0 npm run test:cpp",
+    "test:sandbox": "SANDBOX_BUILD=1 npm run test:cpp",
     "test:cpp": "bash scripts/test-cpp.sh",
     "clean:cpp": "bash src/bindings/build.sh clean"
   },


### PR DESCRIPTION
## Summary
- add `build:real`, `build:sandbox`, `test:real` and `test:sandbox` npm scripts
- document how to use these scripts in README

## Testing
- `npm test` *(fails: No RKLLM model found)*
- `npm run build:real` *(fails: Node.js addon API not found)*

------
https://chatgpt.com/codex/tasks/task_e_68638170877483279f889812ca244916